### PR TITLE
Item capabilities fix

### DIFF
--- a/src/main/java/su/terrafirmagreg/core/mixins/common/gtceu/NotifiableItemStackHandlerMixin.java
+++ b/src/main/java/su/terrafirmagreg/core/mixins/common/gtceu/NotifiableItemStackHandlerMixin.java
@@ -1,0 +1,211 @@
+package su.terrafirmagreg.core.mixins.common.gtceu;
+import com.gregtechceu.gtceu.api.machine.trait.ICapabilityTrait;
+import com.gregtechceu.gtceu.api.machine.trait.NotifiableItemStackHandler;
+
+import com.lowdragmc.lowdraglib.side.item.forge.ItemTransferHelperImpl;
+
+import net.minecraftforge.common.MinecraftForge;
+import net.minecraft.client.Minecraft;
+import net.minecraft.network.chat.ChatType;
+import net.minecraft.network.chat.OutgoingChatMessage;
+import net.minecraft.network.chat.PlayerChatMessage;
+import net.minecraft.world.entity.player.Player;
+import net.minecraft.world.item.ItemStack;
+import net.minecraftforge.event.AttachCapabilitiesEvent;
+
+import org.jetbrains.annotations.NotNull;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Overwrite;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+import org.spongepowered.asm.mixin.injection.callback.LocalCapture;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.Redirect;
+import org.spongepowered.asm.mixin.injection.invoke.arg.Args;
+import org.spongepowered.asm.mixin.injection.ModifyArgs;
+import com.llamalad7.mixinextras.sugar.ref.LocalRef;
+import com.llamalad7.mixinextras.sugar.Local;
+import javax.annotation.Nullable;
+import net.minecraft.world.level.block.entity.BlockEntity;
+
+import it.unimi.dsi.fastutil.ints.IntArrayList;
+import it.unimi.dsi.fastutil.ints.IntList;
+import net.minecraft.core.BlockPos;
+import net.minecraft.core.Direction;
+import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.item.Item;
+import net.minecraft.world.level.Level;
+import net.minecraftforge.common.capabilities.ForgeCapabilities;
+import net.minecraftforge.items.IItemHandler;
+import net.minecraftforge.items.IItemHandlerModifiable;
+import net.minecraftforge.items.ItemHandlerHelper;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.function.Predicate;
+import net.minecraft.nbt.CompoundTag;
+import net.minecraftforge.common.capabilities.ForgeCapabilities;
+
+import com.lowdragmc.lowdraglib.side.item.IItemTransfer;
+import net.minecraftforge.common.capabilities.CapabilityDispatcher;
+import java.util.Optional;
+import java.util.Set;
+import net.dries007.tfc.common.items.TFCItems;
+import com.gregtechceu.gtceu.api.data.chemical.ChemicalHelper;
+import com.gregtechceu.gtceu.api.data.chemical.material.Material;
+import su.terrafirmagreg.core.compat.gtceu.TFGPropertyKeys;
+
+import com.gregtechceu.gtceu.GTCEu;
+import com.gregtechceu.gtceu.api.capability.recipe.IO;
+import com.gregtechceu.gtceu.api.capability.recipe.ItemRecipeCapability;
+import com.gregtechceu.gtceu.api.capability.recipe.RecipeCapability;
+import com.gregtechceu.gtceu.api.machine.MetaMachine;
+import com.gregtechceu.gtceu.api.recipe.GTRecipe;
+import com.gregtechceu.gtceu.api.recipe.DummyCraftingContainer;
+import com.lowdragmc.lowdraglib.misc.ItemStackTransfer;
+import com.lowdragmc.lowdraglib.side.item.IItemTransfer;
+import com.lowdragmc.lowdraglib.side.item.ItemTransferHelper;
+import com.lowdragmc.lowdraglib.syncdata.annotation.DescSynced;
+import com.lowdragmc.lowdraglib.syncdata.annotation.Persisted;
+import com.lowdragmc.lowdraglib.syncdata.field.ManagedFieldHolder;
+import dev.latvian.mods.kubejs.recipe.ingredientaction.IngredientAction;
+import lombok.Getter;
+import net.minecraft.core.Direction;
+import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.item.crafting.Ingredient;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Iterator;
+import java.util.List;
+import java.util.function.Function;
+
+
+// This mixin is used to fix compatibility between TFC, GTCEu-M & AE2
+// GTMachines produce items with their capabilities lazily initialized
+// When the items get transferred to a AE2 system the item capabilities remain unresolved
+// When the items get converted to AEKey they conflict with the items with resolved capabilities
+// To fix this, we resolve the capabilities for GTCEu items registered to contain the heat capability before they get transfered
+//
+// Note: Deprecated for versions of GTCEu-Modern 1.5+
+// Slight alteration required
+@Mixin(value = NotifiableItemStackHandler.class, remap = false)
+public abstract class NotifiableItemStackHandlerMixin {
+
+
+    //THIS VERSION WORKS, but runs twice on versions before GTCEu-M 1.5
+    //TO update to GTCEu-M 1.5+ replace the method field with handleRecipe
+
+    // @Redirect(
+    //     method = "handleIngredient", // method = "handleRecipe", for GTCEu-M 1.5+
+    //     at = @At(
+    //         value = "INVOKE", 
+    //         target = "Lcom/lowdragmc/lowdraglib/misc/ItemStackTransfer;insertItem(ILnet/minecraft/world/item/ItemStack;Z)Lnet/minecraft/world/item/ItemStack;", //for GTCEu-M 1.5+ target = "Lcom/gregtechceu/gteu/api/transfer/item/CustomItemStackHandler;insertItem(ILnet/minecraft/world/item/ItemStack;Z)Lnet/minecraft/world/item/ItemStack;",
+    //         ordinal = 0
+    //     )
+    // )
+    private static ItemStack injectHandleIngredient(ItemStackTransfer capability, int slot, ItemStack stack, boolean simulated) {
+        // The materials that can be heated and contain the heat capabiltiy are registered in TGMaterialHandler.java
+        // We can check if the item is registered when the material contains the TFC_PROPERTY tag
+        
+        if(!simulated){
+
+            Player player = Minecraft.getInstance().player;
+            if (player != null) {
+                PlayerChatMessage message = PlayerChatMessage.unsigned(player.getUUID(), "non simulated");
+                player.createCommandSourceStack().sendChatMessage(new OutgoingChatMessage.Player(message), false, ChatType.bind(ChatType.CHAT, player));
+            } 
+
+            Material material = ChemicalHelper.getMaterial(stack).material();
+            if(material.hasProperty(TFGPropertyKeys.TFC_PROPERTY)){
+                // Force capability resolution immediately after copying
+                stack.getCapability(ForgeCapabilities.ITEM_HANDLER, null).ifPresent(handler -> {
+                    // Just accessing it ensures it's initialized
+                });
+            }
+        }else{
+            Player player = Minecraft.getInstance().player;
+            if (player != null) {
+                PlayerChatMessage message = PlayerChatMessage.unsigned(player.getUUID(), "simulated");
+                player.createCommandSourceStack().sendChatMessage(new OutgoingChatMessage.Player(message), false, ChatType.bind(ChatType.CHAT, player));
+            } 
+        }
+            
+        ItemStack returnStack = capability.insertItem(slot, stack, simulated);
+        return returnStack;
+    }
+}
+
+// These are just some versions that might work, but dont
+
+ // // @Redirect(
+    // //     method = "handleIngredient", 
+    // //     at = @At(
+    // //         value = "INVOKE", 
+    // //         target = "Lnet/minecraft/world/item/ItemStack;copy()Lnet/minecraft/world/item/ItemStack;",
+    // //         ordinal = 0
+    // //     )
+    // // )
+    // // private static ItemStack removeCopy(ItemStack stack) {
+    // //     // Remove it to save resources
+    // //     return null;
+    // // }
+
+    // @Redirect(
+    //     method = "handleIngredient", 
+    //     at = @At(
+    //         // The point the actual item is transferred is within LDlib. We inject the capability resolution right before the item gets inserted
+    //         value = "INVOKE", 
+    //         target = "Lcom/lowdragmc/lowdraglib/misc/ItemStackTransfer;insertItem(ILnet/minecraft/world/item/ItemStack;Z)Lnet/minecraft/world/item/ItemStack;",
+    //         ordinal = 0
+    //     )
+    // )
+    // private static ItemStack redirectInsertItem(ItemStackTransfer capability, int slot, ItemStack stack, boolean simulate){
+    //     return ItemStack.EMPTY;
+    // } 
+
+
+	// @Inject(
+    //     method = "handleIngredient", 
+    //     at = @At(
+    //         // The point the actual item is transferred is within LDlib. We inject the capability resolution right before the item gets inserted
+    //         value = "INVOKE", 
+    //         target = "Lcom/lowdragmc/lowdraglib/misc/ItemStackTransfer;insertItem(ILnet/minecraft/world/item/ItemStack;Z)Lnet/minecraft/world/item/ItemStack;",
+    //         ordinal = 0,
+    //         shift = At.Shift.AFTER
+    //     ),
+    //     locals = LocalCapture.CAPTURE_FAILHARD // Used to capture the simulate variable
+    // )
+    // private static void injectHandleIngredient(
+    //     IO io, GTRecipe recipe, List<Ingredient> left, boolean simulate, IO handlerIO, ItemStackTransfer storage,
+    //     CallbackInfoReturnable<List<Ingredient>> cil, @Local(ordinal=0) ItemStack output, @Local(ordinal = 1) LocalRef<ItemStack> leftStack
+    // ) {
+    //     ItemStack stack = output.copy();
+    //     // The materials that can be heated and contain the heat capabiltiy are registered in TGMaterialHandler.java
+    //     // We can check if the item is registered when the material contains the TFC_PROPERTY tag
+    //     if(!simulate){
+    //         Player player = Minecraft.getInstance().player;
+    //         if (player != null) {
+    //             PlayerChatMessage message = PlayerChatMessage.unsigned(player.getUUID(), "non simulated");
+    //             player.createCommandSourceStack().sendChatMessage(new OutgoingChatMessage.Player(message), false, ChatType.bind(ChatType.CHAT, player));
+    //         } 
+
+    //         Material material = ChemicalHelper.getMaterial(stack).material();
+    //         if(material.hasProperty(TFGPropertyKeys.TFC_PROPERTY)){
+    //             // Force capability resolution immediately after copying
+    //             stack.getCapability(ForgeCapabilities.ITEM_HANDLER, null).ifPresent(handler -> {
+    //                 // Just accessing it ensures it's initialized
+    //             });
+    //         }
+    //     }else{
+    //         Player player = Minecraft.getInstance().player;
+    //         if (player != null) {
+    //             PlayerChatMessage message = PlayerChatMessage.unsigned(player.getUUID(), "simulated");
+    //             player.createCommandSourceStack().sendChatMessage(new OutgoingChatMessage.Player(message), false, ChatType.bind(ChatType.CHAT, player));
+    //         } 
+    //     }
+    //     leftStack.set(stack);
+    // }
+
+

--- a/src/main/java/su/terrafirmagreg/core/mixins/common/gtceu/NotifiableItemStackHandlerMixin.java
+++ b/src/main/java/su/terrafirmagreg/core/mixins/common/gtceu/NotifiableItemStackHandlerMixin.java
@@ -110,13 +110,6 @@ public abstract class NotifiableItemStackHandlerMixin {
         // We can check if the item is registered when the material contains the TFC_PROPERTY tag
         
         if(!simulated){
-
-            Player player = Minecraft.getInstance().player;
-            if (player != null) {
-                PlayerChatMessage message = PlayerChatMessage.unsigned(player.getUUID(), "non simulated");
-                player.createCommandSourceStack().sendChatMessage(new OutgoingChatMessage.Player(message), false, ChatType.bind(ChatType.CHAT, player));
-            } 
-
             Material material = ChemicalHelper.getMaterial(stack).material();
             if(material.hasProperty(TFGPropertyKeys.TFC_PROPERTY)){
                 // Force capability resolution immediately after copying
@@ -124,12 +117,6 @@ public abstract class NotifiableItemStackHandlerMixin {
                     // Just accessing it ensures it's initialized
                 });
             }
-        }else{
-            Player player = Minecraft.getInstance().player;
-            if (player != null) {
-                PlayerChatMessage message = PlayerChatMessage.unsigned(player.getUUID(), "simulated");
-                player.createCommandSourceStack().sendChatMessage(new OutgoingChatMessage.Player(message), false, ChatType.bind(ChatType.CHAT, player));
-            } 
         }
             
         ItemStack returnStack = capability.insertItem(slot, stack, simulated);

--- a/src/main/java/su/terrafirmagreg/core/mixins/common/gtceu/NotifiableItemStackHandlerMixin.java
+++ b/src/main/java/su/terrafirmagreg/core/mixins/common/gtceu/NotifiableItemStackHandlerMixin.java
@@ -1,6 +1,7 @@
 package su.terrafirmagreg.core.mixins.common.gtceu;
 import com.gregtechceu.gtceu.api.machine.trait.ICapabilityTrait;
 import com.gregtechceu.gtceu.api.machine.trait.NotifiableItemStackHandler;
+import com.gregtechceu.gtceu.api.transfer.item.CustomItemStackHandler;
 
 import com.lowdragmc.lowdraglib.side.item.forge.ItemTransferHelperImpl;
 
@@ -97,15 +98,15 @@ public abstract class NotifiableItemStackHandlerMixin {
     //THIS VERSION WORKS, but runs twice on versions before GTCEu-M 1.5
     //TO update to GTCEu-M 1.5+ replace the method field with handleRecipe
 
-    // @Redirect(
-    //     method = "handleIngredient", // method = "handleRecipe", for GTCEu-M 1.5+
-    //     at = @At(
-    //         value = "INVOKE", 
-    //         target = "Lcom/lowdragmc/lowdraglib/misc/ItemStackTransfer;insertItem(ILnet/minecraft/world/item/ItemStack;Z)Lnet/minecraft/world/item/ItemStack;", //for GTCEu-M 1.5+ target = "Lcom/gregtechceu/gteu/api/transfer/item/CustomItemStackHandler;insertItem(ILnet/minecraft/world/item/ItemStack;Z)Lnet/minecraft/world/item/ItemStack;",
-    //         ordinal = 0
-    //     )
-    // )
-    private static ItemStack injectHandleIngredient(ItemStackTransfer capability, int slot, ItemStack stack, boolean simulated) {
+    @Redirect(
+        method = "handleRecipe", 
+        at = @At(
+            value = "INVOKE", 
+            target = "Lcom/gregtechceu/gtceu/api/transfer/item/CustomItemStackHandler;insertItem(ILnet/minecraft/world/item/ItemStack;Z)Lnet/minecraft/world/item/ItemStack;",
+            ordinal = 0
+        )
+    )
+    private static ItemStack injectHandleIngredient(CustomItemStackHandler capability, int slot, ItemStack stack, boolean simulated) {
         // The materials that can be heated and contain the heat capabiltiy are registered in TGMaterialHandler.java
         // We can check if the item is registered when the material contains the TFC_PROPERTY tag
         

--- a/src/main/java/su/terrafirmagreg/core/mixins/common/ldlib/ItemTransferHelperImplMixin.java
+++ b/src/main/java/su/terrafirmagreg/core/mixins/common/ldlib/ItemTransferHelperImplMixin.java
@@ -1,0 +1,108 @@
+package su.terrafirmagreg.core.mixins.common.ldlib;
+import com.gregtechceu.gtceu.api.machine.trait.ICapabilityTrait;
+import com.gregtechceu.gtceu.api.machine.trait.NotifiableItemStackHandler;
+
+import com.lowdragmc.lowdraglib.side.item.forge.ItemTransferHelperImpl;
+
+import dev.architectury.patchedmixin.staticmixin.spongepowered.asm.mixin.Shadow;
+import net.minecraftforge.common.MinecraftForge;
+import net.minecraft.client.Minecraft;
+import net.minecraft.network.chat.ChatType;
+import net.minecraft.network.chat.OutgoingChatMessage;
+import net.minecraft.network.chat.PlayerChatMessage;
+import net.minecraft.world.entity.player.Player;
+import net.minecraft.world.item.ItemStack;
+import net.minecraftforge.event.AttachCapabilitiesEvent;
+
+import org.jetbrains.annotations.NotNull;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Overwrite;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+import org.spongepowered.asm.mixin.injection.callback.LocalCapture;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import com.llamalad7.mixinextras.sugar.ref.LocalRef;
+import javax.annotation.Nullable;
+import net.minecraft.world.level.block.entity.BlockEntity;
+
+import it.unimi.dsi.fastutil.ints.IntArrayList;
+import it.unimi.dsi.fastutil.ints.IntList;
+import net.minecraft.core.BlockPos;
+import net.minecraft.core.Direction;
+import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.level.Level;
+import net.minecraftforge.common.capabilities.ForgeCapabilities;
+import net.minecraftforge.items.IItemHandler;
+import net.minecraftforge.items.IItemHandlerModifiable;
+import net.minecraftforge.items.ItemHandlerHelper;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.function.Predicate;
+import net.minecraft.nbt.CompoundTag;
+import net.minecraftforge.common.capabilities.ForgeCapabilities;
+
+import com.lowdragmc.lowdraglib.side.item.IItemTransfer;
+import net.minecraftforge.common.capabilities.CapabilityDispatcher;
+import java.util.Optional;
+
+@Mixin(value = ItemTransferHelperImpl.class, remap = false)
+public abstract class ItemTransferHelperImplMixin {
+
+	@Inject(
+        method = "exportToTarget", 
+        at = @At(
+            value = "INVOKE", 
+            target = "Lcom/lowdragmc/lowdraglib/side/item/forge/ItemTransferHelperImpl;insertItem(Lnet/minecraftforge/items/IItemHandler;Lnet/minecraft/world/item/ItemStack;Z)Lnet/minecraft/world/item/ItemStack;", 
+            ordinal = 1
+        ), 
+        locals = LocalCapture.CAPTURE_FAILHARD,
+        cancellable = false
+    )
+    private static void injectExportToTarget(
+            IItemTransfer source, int maxAmount, Predicate<ItemStack> predicate, Level level, BlockPos pos, @Nullable Direction direction,
+            CallbackInfo ci, BlockEntity blockEntity, Optional<IItemHandler> cap, IItemHandler target, int srcIndex, ItemStack sourceStack) {
+
+        if (!sourceStack.isEmpty()) {
+            sourceStack.getCapability(ForgeCapabilities.ITEM_HANDLER, null).resolve();
+        }
+        
+    }
+
+}
+
+
+/*
+        String className = target.getClass().getName();
+        boolean targetIsGTCEuHandler = className.startsWith("com.gregtechceu");
+		boolean sourceIsGTCEuHandler = source instanceof NotifiableItemStackHandler;
+
+        Player player = Minecraft.getInstance().player;
+        if (player != null) {
+            PlayerChatMessage targetIsGTCEuHandlerMessage = PlayerChatMessage.unsigned(player.getUUID(), targetIsGTCEuHandler ? "targetIsGTCEuHandler" : "not Target" + target.getClass().getName());
+            PlayerChatMessage sourceIsGTCEuHandlerMessage = PlayerChatMessage.unsigned(player.getUUID(), sourceIsGTCEuHandler ? "sourceIsGTCEuHandler" : "not source");
+            player.createCommandSourceStack().sendChatMessage(new OutgoingChatMessage.Player(targetIsGTCEuHandlerMessage), false, ChatType.bind(ChatType.CHAT, player));
+            player.createCommandSourceStack().sendChatMessage(new OutgoingChatMessage.Player(sourceIsGTCEuHandlerMessage), false, ChatType.bind(ChatType.CHAT, player));
+
+        } 
+
+        // If the target is not GTCEu, force capability resolution
+        if (!targetIsGTCEuHandler && sourceIsGTCEuHandler) {
+
+            if(player!=null){
+                PlayerChatMessage attach = PlayerChatMessage.unsigned(player.getUUID(), "attach");
+                player.createCommandSourceStack().sendChatMessage(new OutgoingChatMessage.Player(attach), false, ChatType.bind(ChatType.CHAT, player));
+            }
+            if (!sourceStack.isEmpty()) {
+                sourceStack.getCapability(ForgeCapabilities.ITEM_HANDLER, null).resolve();
+                // sourceStack.getCapability(ForgeCapabilities.ITEM_HANDLER, null).ifPresent(handler -> {
+                //     CompoundTag handlerTag = new CompoundTag();
+                //     for (int i = 0; i < handler.getSlots(); i++) {
+                //         ItemStack slotStack = handler.getStackInSlot(i);
+                //         handlerTag.put("Slot" + i, slotStack.save(new CompoundTag()));
+                //     }
+                //     sourceStack.getOrCreateTag().put("ForgeCaps", handlerTag);
+                // });
+            }
+        }
+*/

--- a/src/main/java/su/terrafirmagreg/core/mixins/common/ldlib/ItemTransferHelperImplMixin.java
+++ b/src/main/java/su/terrafirmagreg/core/mixins/common/ldlib/ItemTransferHelperImplMixin.java
@@ -66,17 +66,17 @@ public abstract class ItemTransferHelperImplMixin {
 
 
 
-	@Inject(
-        method = "exportToTarget", 
-        at = @At(
-            // The point the actual item is transferred is within LDlib. We inject the capability resolution right before the item gets inserted
-            value = "INVOKE", 
-            target = "Lcom/lowdragmc/lowdraglib/side/item/forge/ItemTransferHelperImpl;insertItem(Lnet/minecraftforge/items/IItemHandler;Lnet/minecraft/world/item/ItemStack;Z)Lnet/minecraft/world/item/ItemStack;", 
-            ordinal = 1 // The first call of insertItem tests if the items can be inserted, the second call actually inserts the item
-        ), 
-        locals = LocalCapture.CAPTURE_FAILHARD, // Used to capture the sourceStack variable
-        cancellable = false // We do not alter the normal control flow of the function
-    )
+	// @Inject(
+    //     method = "exportToTarget", 
+    //     at = @At(
+    //         // The point the actual item is transferred is within LDlib. We inject the capability resolution right before the item gets inserted
+    //         value = "INVOKE", 
+    //         target = "Lcom/lowdragmc/lowdraglib/side/item/forge/ItemTransferHelperImpl;insertItem(Lnet/minecraftforge/items/IItemHandler;Lnet/minecraft/world/item/ItemStack;Z)Lnet/minecraft/world/item/ItemStack;", 
+    //         ordinal = 1 // The first call of insertItem tests if the items can be inserted, the second call actually inserts the item
+    //     ), 
+    //     locals = LocalCapture.CAPTURE_FAILHARD, // Used to capture the sourceStack variable
+    //     cancellable = false // We do not alter the normal control flow of the function
+    // )
     private static void injectExportToTarget(
             IItemTransfer source, int maxAmount, Predicate<ItemStack> predicate, Level level, BlockPos pos, @Nullable Direction direction,
             CallbackInfo ci, BlockEntity blockEntity, Optional<IItemHandler> cap, IItemHandler target, int srcIndex, ItemStack sourceStack) {

--- a/src/main/java/su/terrafirmagreg/core/mixins/common/ldlib/ItemTransferHelperImplMixin.java
+++ b/src/main/java/su/terrafirmagreg/core/mixins/common/ldlib/ItemTransferHelperImplMixin.java
@@ -4,7 +4,6 @@ import com.gregtechceu.gtceu.api.machine.trait.NotifiableItemStackHandler;
 
 import com.lowdragmc.lowdraglib.side.item.forge.ItemTransferHelperImpl;
 
-import dev.architectury.patchedmixin.staticmixin.spongepowered.asm.mixin.Shadow;
 import net.minecraftforge.common.MinecraftForge;
 import net.minecraft.client.Minecraft;
 import net.minecraft.network.chat.ChatType;
@@ -31,6 +30,7 @@ import it.unimi.dsi.fastutil.ints.IntList;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
 import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.item.Item;
 import net.minecraft.world.level.Level;
 import net.minecraftforge.common.capabilities.ForgeCapabilities;
 import net.minecraftforge.items.IItemHandler;
@@ -45,9 +45,15 @@ import net.minecraftforge.common.capabilities.ForgeCapabilities;
 import com.lowdragmc.lowdraglib.side.item.IItemTransfer;
 import net.minecraftforge.common.capabilities.CapabilityDispatcher;
 import java.util.Optional;
+import java.util.Set;
+import net.dries007.tfc.common.items.TFCItems;
+import com.gregtechceu.gtceu.api.data.chemical.ChemicalHelper;
+import com.gregtechceu.gtceu.api.data.chemical.material.Material;
+import su.terrafirmagreg.core.compat.gtceu.TFGPropertyKeys;
 
 @Mixin(value = ItemTransferHelperImpl.class, remap = false)
 public abstract class ItemTransferHelperImplMixin {
+
 
 	@Inject(
         method = "exportToTarget", 
@@ -62,9 +68,11 @@ public abstract class ItemTransferHelperImplMixin {
     private static void injectExportToTarget(
             IItemTransfer source, int maxAmount, Predicate<ItemStack> predicate, Level level, BlockPos pos, @Nullable Direction direction,
             CallbackInfo ci, BlockEntity blockEntity, Optional<IItemHandler> cap, IItemHandler target, int srcIndex, ItemStack sourceStack) {
-
-        if (!sourceStack.isEmpty()) {
-            sourceStack.getCapability(ForgeCapabilities.ITEM_HANDLER, null).resolve();
+        if (!sourceStack.isEmpty() ) {
+            Material material = ChemicalHelper.getMaterial(sourceStack).material();
+            if(material.hasProperty(TFGPropertyKeys.TFC_PROPERTY)){
+                sourceStack.getCapability(ForgeCapabilities.ITEM_HANDLER, null).resolve();
+            }
         }
         
     }

--- a/src/main/resources/tfg.mixins.json
+++ b/src/main/resources/tfg.mixins.json
@@ -53,7 +53,8 @@
         "common.tfc.IngotPileBlockMixin",
         "common.tfc.ItemSizeManagerMixin",
         "common.tfc.TFCChunkGeneratorMixin",
-        "common.ldlib.ItemTransferHelperImplMixin"
+        "common.ldlib.ItemTransferHelperImplMixin",
+        "common.gtceu.NotifiableItemStackHandlerMixin"
     ],
     "client": [
         "client.ftb.ClientTeamManagerImplMixin",

--- a/src/main/resources/tfg.mixins.json
+++ b/src/main/resources/tfg.mixins.json
@@ -52,7 +52,8 @@
         "common.tfc.IIngotPileBlockEntityEntryAccessor",
         "common.tfc.IngotPileBlockMixin",
         "common.tfc.ItemSizeManagerMixin",
-        "common.tfc.TFCChunkGeneratorMixin"
+        "common.tfc.TFCChunkGeneratorMixin",
+        "common.ldlib.ItemTransferHelperImplMixin"
     ],
     "client": [
         "client.ftb.ClientTeamManagerImplMixin",


### PR DESCRIPTION
Fix for item capabilities not being resolved when items enter AE2 systems.

This PR contains two possible methods to fix this issue, with one disabled as it runs twice every time, but can be altered to work with GTCEu-Modern versions above 1.5.

For now is the enabled version fine as it only runs once an item is transferred.